### PR TITLE
Fix the the type cast error, issue #214

### DIFF
--- a/Face_Detection/align_warp_back_multiple_dlib.py
+++ b/Face_Detection/align_warp_back_multiple_dlib.py
@@ -214,9 +214,9 @@ def blur_blending(im1, im2, mask):
     return np.array(im) / 255.0
 
 
-def blur_blending_cv2(im1, im2, mask):
+def blur_blending_cv2(im1, im2, mask_in):
 
-    mask *= 255.0
+    mask = mask_in * 255.0
 
     kernel = np.ones((9, 9), np.uint8)
     mask = cv2.erode(mask, kernel, iterations=3)

--- a/Face_Detection/align_warp_back_multiple_dlib_HR.py
+++ b/Face_Detection/align_warp_back_multiple_dlib_HR.py
@@ -214,9 +214,9 @@ def blur_blending(im1, im2, mask):
     return np.array(im) / 255.0
 
 
-def blur_blending_cv2(im1, im2, mask):
+def blur_blending_cv2(im1, im2, mask_in):
 
-    mask *= 255.0
+    mask = mask_in * 255.0
 
     kernel = np.ones((9, 9), np.uint8)
     mask = cv2.erode(mask, kernel, iterations=3)


### PR DESCRIPTION
Without the change, there will be an error:  numpy.core._exceptions.UFuncTypeError: Cannot cast ufunc 'multiply' output from dtype('float64') to dtype('uint8') with casting rule 'same_kind'

[](https://github.com/microsoft/Bringing-Old-Photos-Back-to-Life/issues/214)
