### PR TITLE
fix save model mapping

### DIFF
--- a/Global/models/mapping_model.py
+++ b/Global/models/mapping_model.py
@@ -345,6 +345,11 @@ class Pix2PixHDModel_Mapping(BaseModel):
         fake_image = self.netG_B.forward(label_feat_map, flow="dec")
         return fake_image
 
+    def save(self, which_epoch):
+        self.save_network(self.netD, 'D', which_epoch, self.gpu_ids)
+        self.save_network(self.mapping_net, 'mapping_net', which_epoch, self.gpu_ids)
+        self.save_optimizer(self.optimizer_D,"D",which_epoch)
+        self.save_optimizer(self.optimizer_mapping, 'mapping_net', which_epoch)
 
 class InferenceModel(Pix2PixHDModel_Mapping):
     def forward(self, label, inst):


### PR DESCRIPTION
I don't know if this is a bug, but I can't save the model when training model mapping. I found that you didn't implement save function in `Pix2PixHDModel_Mapping`. I see that some people also have the same trouble in #193. I hope that this pull request would help.